### PR TITLE
feat(role): implement RoleRepository with MySQL and add RoleSeeder

### DIFF
--- a/applications/app-service/build.gradle
+++ b/applications/app-service/build.gradle
@@ -1,6 +1,9 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
+	implementation project(':seeder')
+	implementation 'org.reactivecommons.utils:object-mapper:0.1.0'
+	implementation project(':jpa-repository')
     implementation project(':model')
     implementation project(':usecase')
     implementation 'org.springframework.boot:spring-boot-starter'
@@ -23,4 +26,3 @@ bootJar {
     // Sets output jar name
     archiveFileName = "${project.getParent().getName()}.${archiveExtension.get()}"
 }
-

--- a/applications/app-service/src/main/java/cue/edu/co/config/ObjectMapperConfig.java
+++ b/applications/app-service/src/main/java/cue/edu/co/config/ObjectMapperConfig.java
@@ -1,0 +1,16 @@
+package cue.edu.co.config;
+
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ObjectMapperConfig {
+
+    @Bean
+    public ObjectMapper objectMapper() {
+        return new ObjectMapperImp();
+    }
+
+}

--- a/applications/app-service/src/main/resources/application.yaml
+++ b/applications/app-service/src/main/resources/application.yaml
@@ -1,14 +1,16 @@
-##Spring Configuration
 server:
   port: 8080
 spring:
   application:
-    name: cue-event-manager
+    name: "cue-event-manager"
   devtools:
     add-properties: false
-  h2:
-    console:
-      enabled: true
-      path: /h2
   profiles:
-    include:
+    include: null
+  datasource:
+    url: "jdbc:mysql://localhost:3306/authdb"
+    username: "root"
+    password: "admin123"
+    driverClassName: com.mysql.cj.jdbc.Driver
+  jpa:
+    databasePlatform: org.hibernate.dialect.MySQL8Dialect

--- a/applications/app-service/src/test/java/cue/edu/co/config/ObjectMapperConfigTest.java
+++ b/applications/app-service/src/test/java/cue/edu/co/config/ObjectMapperConfigTest.java
@@ -1,0 +1,20 @@
+package cue.edu.co.config;
+
+import org.junit.jupiter.api.Test;
+import org.reactivecommons.utils.ObjectMapper;
+import org.reactivecommons.utils.ObjectMapperImp;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class ObjectMapperConfigTest {
+
+    @Test
+    void testObjectMapperBean() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext(ObjectMapperConfig.class);
+        ObjectMapper objectMapper = context.getBean(ObjectMapper.class);
+        assertNotNull(objectMapper);
+        assertTrue(objectMapper instanceof ObjectMapperImp);
+        context.close();
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,9 @@ buildscript {
 		jacocoVersion = '0.8.13'
 		pitestVersion = '1.19.0-rc.1'
         lombokVersion = '1.18.38'
-	}
+        mysqlConnectorVersion = '8.0.33'
+        mapstructVersion = '1.6.3'
+    }
 }
 
 plugins {

--- a/domain/model/src/main/java/cue/edu/co/model/role/Role.java
+++ b/domain/model/src/main/java/cue/edu/co/model/role/Role.java
@@ -1,14 +1,13 @@
 package cue.edu.co.model.role;
-import lombok.Builder;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-//import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
-@Getter
-@Setter
-//@NoArgsConstructor
-@AllArgsConstructor
-@Builder(toBuilder = true)
+import java.time.LocalDate;
+
+@Data
+@Builder
 public class Role {
+    private Long id;
+    private String name;
+    private String description;
+    private LocalDate createdAt;
 }

--- a/domain/model/src/main/java/cue/edu/co/model/role/constants/RoleConstant.java
+++ b/domain/model/src/main/java/cue/edu/co/model/role/constants/RoleConstant.java
@@ -1,0 +1,15 @@
+package cue.edu.co.model.role.constants;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleConstant {
+    ADMIN("ADMIN", "Administrador del sistema"),
+    ORGANIZER("ORGANIZER", "Organizador de eventos"),
+    ATTENDEE("ATTENDEE", "Asistente a eventos");
+
+    private final String name;
+    private final String description;
+}

--- a/domain/model/src/main/java/cue/edu/co/model/role/gateways/RoleRepository.java
+++ b/domain/model/src/main/java/cue/edu/co/model/role/gateways/RoleRepository.java
@@ -1,4 +1,10 @@
 package cue.edu.co.model.role.gateways;
 
+import cue.edu.co.model.role.Role;
+
+import java.util.Optional;
+
 public interface RoleRepository {
+    Role save(Role role);
+    Optional<Role> findByName(String name);
 }

--- a/infrastructure/driven-adapters/jpa-repository/build.gradle
+++ b/infrastructure/driven-adapters/jpa-repository/build.gradle
@@ -1,0 +1,7 @@
+dependencies {
+    implementation project(':model')
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+    implementation "mysql:mysql-connector-java:${mysqlConnectorVersion}"
+    implementation "org.mapstruct:mapstruct:$mapstructVersion"
+    annotationProcessor "org.mapstruct:mapstruct-processor:$mapstructVersion"
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/config/DBSecret.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/config/DBSecret.java
@@ -1,0 +1,12 @@
+package cue.edu.co.jpa.config;
+
+import lombok.Builder;
+import lombok.Getter;
+@Builder
+@Getter
+public class DBSecret {
+    private final String url;
+    private final String username;
+    private final String password;
+
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/config/JpaConfig.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/config/JpaConfig.java
@@ -1,0 +1,56 @@
+package cue.edu.co.jpa.config;
+
+import com.zaxxer.hikari.HikariConfig;
+import com.zaxxer.hikari.HikariDataSource;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+import org.springframework.orm.jpa.JpaVendorAdapter;
+import org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean;
+import org.springframework.orm.jpa.vendor.HibernateJpaVendorAdapter;
+
+import javax.sql.DataSource;
+import java.util.Properties;
+
+@Configuration
+public class JpaConfig {
+
+    @Bean
+    public DBSecret dbSecret(Environment env) {
+        return DBSecret.builder()
+                .url(env.getProperty("spring.datasource.url"))
+                .username(env.getProperty("spring.datasource.username"))
+                .password(env.getProperty("spring.datasource.password"))
+                .build();
+    }
+
+    @Bean
+    public DataSource datasource(DBSecret secret, @Value("${spring.datasource.driverClassName}") String driverClass) {
+        HikariConfig config = new HikariConfig();
+        config.setJdbcUrl(secret.getUrl());
+        config.setUsername(secret.getUsername());
+        config.setPassword(secret.getPassword());
+        config.setDriverClassName(driverClass);
+        return new HikariDataSource(config);
+    }
+
+    @Bean
+    public LocalContainerEntityManagerFactoryBean entityManagerFactory(
+            DataSource dataSource,
+            @Value("${spring.jpa.databasePlatform}") String dialect) {
+        LocalContainerEntityManagerFactoryBean em = new LocalContainerEntityManagerFactoryBean();
+        em.setDataSource(dataSource);
+        em.setPackagesToScan("cue.edu.co.jpa");
+
+        JpaVendorAdapter vendorAdapter = new HibernateJpaVendorAdapter();
+        em.setJpaVendorAdapter(vendorAdapter);
+
+        Properties properties = new Properties();
+        properties.setProperty("hibernate.dialect", dialect);
+        properties.setProperty("hibernate.hbm2ddl.auto", "update");
+        em.setJpaProperties(properties);
+
+        return em;
+    }
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/entities/RoleEntity.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/entities/RoleEntity.java
@@ -1,0 +1,29 @@
+package cue.edu.co.jpa.entities;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "roles")
+public class RoleEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String name;
+
+    @Column(nullable = false)
+    private String description;
+
+    @Column(nullable = false)
+    private LocalDateTime createdAt;
+
+    @PrePersist
+    protected void onCreate() {
+        createdAt = LocalDateTime.now();
+    }
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/mappers/RoleEntityMapper.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/mappers/RoleEntityMapper.java
@@ -1,0 +1,11 @@
+package cue.edu.co.jpa.mappers;
+
+import cue.edu.co.jpa.entities.RoleEntity;
+import cue.edu.co.model.role.Role;
+import org.mapstruct.Mapper;
+
+@Mapper(componentModel = "spring")
+public interface RoleEntityMapper {
+    Role toDomain(RoleEntity role);
+    RoleEntity toEntity(Role role);
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/repositories/RoleJpaRepository.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/repositories/RoleJpaRepository.java
@@ -1,0 +1,10 @@
+package cue.edu.co.jpa.repositories;
+
+import cue.edu.co.jpa.entities.RoleEntity;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface RoleJpaRepository extends CrudRepository<RoleEntity, Long> {
+    Optional<RoleEntity> findByName(String name);
+}

--- a/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/repositories/impl/RoleRepositoryMySQLAdapter.java
+++ b/infrastructure/driven-adapters/jpa-repository/src/main/java/cue/edu/co/jpa/repositories/impl/RoleRepositoryMySQLAdapter.java
@@ -1,0 +1,32 @@
+package cue.edu.co.jpa.repositories.impl;
+
+import cue.edu.co.jpa.entities.RoleEntity;
+import cue.edu.co.jpa.mappers.RoleEntityMapper;
+import cue.edu.co.jpa.repositories.RoleJpaRepository;
+import cue.edu.co.model.role.Role;
+import cue.edu.co.model.role.gateways.RoleRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class RoleRepositoryMySQLAdapter implements RoleRepository {
+
+    private final RoleJpaRepository roleJpaRepository;
+    private final RoleEntityMapper roleEntityMapper;
+
+    @Override
+    public Role save(Role role) {
+        RoleEntity roleSaved = roleJpaRepository.save(roleEntityMapper.toEntity(role));
+        return roleEntityMapper.toDomain(roleSaved);
+    }
+
+    @Override
+    public Optional<Role> findByName(String name) {
+        return roleJpaRepository
+                .findByName(name)
+                .map(roleEntityMapper::toDomain);
+    }
+}

--- a/infrastructure/entry-points/seeder/build.gradle
+++ b/infrastructure/entry-points/seeder/build.gradle
@@ -1,0 +1,6 @@
+dependencies {
+    implementation project(':model')
+    implementation project(':usecase')
+    implementation 'org.springframework:spring-context'
+    implementation 'org.springframework.boot:spring-boot-starter'
+}

--- a/infrastructure/entry-points/seeder/src/main/java/cue/edu/co/seeder/constant/RoleSeederLog.java
+++ b/infrastructure/entry-points/seeder/src/main/java/cue/edu/co/seeder/constant/RoleSeederLog.java
@@ -1,0 +1,15 @@
+package cue.edu.co.seeder.constant;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum RoleSeederLog {
+    STARTING("Starting role seeder..."),
+    ROLE_FOUND("Role already exists: {}"),
+    ROLE_CREATED("Role created: {}"),
+    FINISHED("Role seeder finished.");
+
+    private final String message;
+}

--- a/infrastructure/entry-points/seeder/src/main/java/cue/edu/co/seeder/seeders/RoleSeeder.java
+++ b/infrastructure/entry-points/seeder/src/main/java/cue/edu/co/seeder/seeders/RoleSeeder.java
@@ -1,0 +1,41 @@
+package cue.edu.co.seeder.seeders;
+
+import cue.edu.co.model.role.Role;
+import cue.edu.co.model.role.constants.RoleConstant;
+import cue.edu.co.model.role.gateways.RoleRepository;
+import cue.edu.co.seeder.constant.RoleSeederLog;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class RoleSeeder implements CommandLineRunner {
+
+    private final RoleRepository roleRepository;
+
+    @Override
+    public void run(String... args) {
+        log.info(RoleSeederLog.STARTING.getMessage());
+
+        for (RoleConstant roleConstant : RoleConstant.values()) {
+            roleRepository.findByName(roleConstant.getName())
+                    .ifPresentOrElse(
+                            role -> log.info(RoleSeederLog.ROLE_FOUND.getMessage(), roleConstant.getName()),
+                            () -> {
+                                Role newRole = Role.builder()
+                                        .name(roleConstant.getName())
+                                        .description(roleConstant.getDescription())
+                                        .build();
+
+                                roleRepository.save(newRole);
+                                log.info(RoleSeederLog.ROLE_CREATED.getMessage(), roleConstant.getName());
+                            }
+                    );
+        }
+
+        log.info(RoleSeederLog.FINISHED.getMessage());
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -20,3 +20,7 @@ include ':usecase'
 project(':app-service').projectDir = file('./applications/app-service')
 project(':model').projectDir = file('./domain/model')
 project(':usecase').projectDir = file('./domain/usecase')
+include ':jpa-repository'
+project(':jpa-repository').projectDir = file('./infrastructure/driven-adapters/jpa-repository')
+include ':seeder'
+project(':seeder').projectDir = file('./infrastructure/entry-points/seeder')


### PR DESCRIPTION
### Overview
- Added MySQL connector and MapStruct dependencies to build configuration.
- Implemented RoleRepository and updated Role entity to support MySQL persistence.
- Introduced RoleConstant enum for default role names and descriptions.
- Created RoleSeeder to insert default roles into the database.
- Added ObjectMapper configuration with corresponding unit test.

### Motivation
This PR establishes the foundation for role management by ensuring roles are persisted in MySQL and default roles are available during application startup.

### Changes
- Build configuration updated with MySQL connector and MapStruct.
- Domain layer updated with Role entity and RoleRepository.
- Infrastructure layer includes RoleSeeder for default roles.
- New ObjectMapperConfig with unit tests for consistent JSON serialization.

### Next Steps
- Integrate role-based access control in authentication service.
- Expand seeder support for other domain constants.
